### PR TITLE
set tabindex: 0 along with aria-hidden: false

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -192,7 +192,8 @@
         var _ = this;
 
         _.$slideTrack.find('.slick-active').attr({
-            'aria-hidden': 'false'
+            'aria-hidden': 'false',
+            'tabindex': '0'
         }).find('a, input, button, select').attr({
             'tabindex': '0'
         });


### PR DESCRIPTION
This fix will resolve tab navigation between with carousel items issue.
issue occurs due to tabindex: -1 to always in item wrapper element (while child element set to tabindex: 0 correctly)

